### PR TITLE
Add 5.2 to require pipeline steps are defined in code

### DIFF
--- a/SUPPORTABILITY.md
+++ b/SUPPORTABILITY.md
@@ -69,6 +69,7 @@ Ensuring that your project adheres to the following RFCs is a good first step as
   * [ ] 5.1.4 Manual step to deploy to `production` environment
   * [ ] 5.1.5 Zero-downtime deployment step to production
   * [ ] 5.1.6 Manual step to flip between blue/green environment
+* [ ] 5.2 All pipeline steps are defined in code within repository for chosen pipeline service
 
 ### 6. Application logging
 


### PR DESCRIPTION
Often, Continuous Delivery pipelines are things that take a while to setup, and having these defined in code serves as good visibility on what happens when onboarding into a project, but also as a backup, rather than the pipeline configuration being full stored just in a service or system. It also allows for easy sharing of pipeline configurations across projects.